### PR TITLE
CI: Using cache for pipi dependences

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+          cache: pip
       - name: Create venv and install python packages
         run: |
           python -m pip install --upgrade pip && pip install -r dev-requirements.txt && pip install -r requirements.txt

--- a/stocklake/exceptions.py
+++ b/stocklake/exceptions.py
@@ -1,4 +1,3 @@
 class StockLoaderException(Exception):
     def __init__(self, message: str):
-        super().__init__()
-        self.message = message
+        super().__init__(message)


### PR DESCRIPTION
Adding Github Actions Cache for pip dependences

close #26