### PR TITLE
Add JSON format to save data as local artifact

### DIFF
--- a/stocklake/stores/constants.py
+++ b/stocklake/stores/constants.py
@@ -15,7 +15,7 @@ class StoreType(str, Enum):
 
 class ArtifactFormat(str, Enum):
     CSV = "csv"
-    # JSON = "json"
+    JSON = "json"
 
     @staticmethod
     def formats():

--- a/stocklake/wiki_sp500/stores.py
+++ b/stocklake/wiki_sp500/stores.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import json
 from typing import List, Optional
 
 from stocklake.core.base_sqlalchemy_store import SQLAlchemyStore
@@ -38,6 +39,11 @@ class WikiSP500Store(BaseStore):
                     csv_file_path = os.path.join(tmpdir, "wiki_sp500.csv")
                     save_data_to_csv([d.model_dump() for d in data], csv_file_path)
                     repository.save_artifact(csv_file_path)
+                elif artifact_format == ArtifactFormat.JSON:
+                    json_file_path = os.path.join(tmpdir, "wiki_sp500.json")
+                    with open(json_file_path, "w") as json_file:
+                        json.dump([d.model_dump() for d in data], json_file)
+                    repository.save_artifact(json_file_path)
                 else:
                     raise NotImplementedError()
             return repository.list_artifacts()[0].path

--- a/stocklake/wiki_sp500/stores.py
+++ b/stocklake/wiki_sp500/stores.py
@@ -1,7 +1,6 @@
 import json
 import os
 import tempfile
-import json
 from typing import List, Optional
 
 from stocklake.core.base_sqlalchemy_store import SQLAlchemyStore

--- a/stocklake/wiki_sp500/stores.py
+++ b/stocklake/wiki_sp500/stores.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 from typing import List, Optional
@@ -38,6 +39,11 @@ class WikiSP500Store(BaseStore):
                     csv_file_path = os.path.join(tmpdir, "wiki_sp500.csv")
                     save_data_to_csv([d.model_dump() for d in data], csv_file_path)
                     repository.save_artifact(csv_file_path)
+                elif artifact_format == ArtifactFormat.JSON:
+                    json_file_path = os.path.join(tmpdir, "wiki_sp500.json")
+                    with open(json_file_path, "w") as json_file:
+                        json.dump([d.model_dump() for d in data], json_file)
+                    repository.save_artifact(json_file_path)
                 else:
                     raise NotImplementedError()
             return repository.list_artifacts()[0].path

--- a/tests/wiki_sp500/test_stores.py
+++ b/tests/wiki_sp500/test_stores.py
@@ -21,7 +21,7 @@ def wiki_sp500_data():
 
 
 @pytest.mark.parametrize(
-    "artifact_format", [None, ArtifactFormat.CSV, "INVALID_FORMAT"]
+    "artifact_format", [None, ArtifactFormat.CSV, ArtifactFormat.JSON, "INVALID_FORMAT"]
 )
 def test_save_local_artifact_repo(artifact_format, wiki_sp500_data):
     store = WikiSP500Store()


### PR DESCRIPTION
Related to #238

Add support for saving wiki500 data in JSON format.

* **stocklake/stores/constants.py**
  - Add `JSON` to `ArtifactFormat` enum.
  - Update `formats` method to include `JSON`.

* **stocklake/wiki_sp500/stores.py**
  - Add support for saving data in JSON format in `WikiSP500Store` class.
  - Update `save` method to handle `ArtifactFormat.JSON`.

* **tests/wiki_sp500/test_stores.py**
  - Add test cases for saving data in JSON format.
  - Verify `WikiSP500Store` class handles `ArtifactFormat.JSON` correctly.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tsugumi-sys/stocklake/issues/238?shareId=cf083f7d-f4ab-448c-af1a-92bfcb9010a3).